### PR TITLE
Building wheels for Windows (close #26)

### DIFF
--- a/.github/workflows/win_wheels.yml
+++ b/.github/workflows/win_wheels.yml
@@ -1,0 +1,81 @@
+name: Win-Wheels
+
+on:
+  push:
+    # branches: [ devel ]
+    tags: [ '*' ]
+  workflow_dispatch:
+
+jobs:
+  build_win_wheels:
+    name: Build ${{ matrix.cibw-only }} wheel
+
+    strategy:
+      matrix: 
+        include:
+          #windows wheels
+          - cibw-only: cp38-win_amd64
+            os: windows-latest
+          - cibw-only: cp39-win_amd64
+            os: windows-latest
+          - cibw-only: cp310-win_amd64
+            os: windows-latest
+          - cibw-only: cp311-win_amd64
+            os: windows-latest
+          #linux wheels
+          # - cibw-only: cp38-manylinux_x86_64
+          #   os: ubuntu-latest
+          # - cibw-only: cp39-manylinux_x86_64
+          #   os: ubuntu-latest
+          # - cibw-only: cp310-manylinux_x86_64
+          #   os: ubuntu-latest
+          # - cibw-only: cp311-manylinux_x86_64
+          #   os: ubuntu-latest
+    defaults:
+      run: # 
+        shell: ${{ matrix.os == 'windows-latest' && 'msys2 {0}' || 'bash' }} 
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout source
+      uses: actions/checkout@v4
+
+    - name: Set up MSYS2
+      if: ${{ runner.os == 'Windows' }}
+      uses: msys2/setup-msys2@v2
+      with:
+        release: false
+        msystem: ucrt64
+        install: make mingw-w64-ucrt-x86_64-cmake mingw-w64-ucrt-x86_64-gcc mingw-w64-ucrt-x86_64-gcc-fortran mingw-w64-ucrt-x86_64-gcc-libgfortran mingw-w64-ucrt-x86_64-gsl mingw-w64-ucrt-x86_64-zlib
+
+    - name: Set up Python
+      id: setup-python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        update-environment: false
+
+    - name: replace '\' to '/' in python path, only effective on windows 
+      id: replace-path
+      run: echo "py_path=$(echo "${{ steps.setup-python.outputs.python-path }}" | sed 's/\\/\//g')" >> $GITHUB_OUTPUT
+
+    - name: install cibuildwheel
+      run: |
+        ${{ steps.replace-path.outputs.py_path }} -m pip install cibuildwheel
+
+    - name: Build binary wheels
+      run: |
+        echo "using python at: ${{ steps.replace-path.outputs.py_path }}"
+        ${{ steps.replace-path.outputs.py_path }} -m cibuildwheel --only ${{ matrix.cibw-only }}
+      env:
+        CIBW_TEST_SKIP: "*"
+
+    - name: Show built files
+      run: ls -la wheelhouse
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: dist-wheels-${{ matrix.cibw-only }}
+        path: ./wheelhouse/*.whl
+

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,7 +1,7 @@
-numpy>=1.23.2  ; python_version < '4.0'  and python_version >= '3.11'  # Python 3.11
-numpy>=1.21.6  ; python_version < '3.11' and python_version >= '3.10'  # Python 3.10
-numpy>=1.21.6  ; python_version < '3.10' and python_version >= '3.9'   # Python 3.9
-numpy>=1.21.6  ; python_version < '3.9'  and python_version >= '3.8'   # Python 3.8
+numpy>=1.23.2,<2  ; python_version < '4.0'  and python_version >= '3.11'  # Python 3.11
+numpy>=1.21.6,<2  ; python_version < '3.11' and python_version >= '3.10'  # Python 3.10
+numpy>=1.21.6,<2  ; python_version < '3.10' and python_version >= '3.9'   # Python 3.9
+numpy>=1.21.6,<2  ; python_version < '3.9'  and python_version >= '3.8'   # Python 3.8
 
 joblib>=1.1.0
 pyyaml>=5.4.1
@@ -9,8 +9,8 @@ pyyaml>=5.4.1
 fiona>=1.8.22  ;  python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
 fiona>=1.8.21  ;  python_version < '3.11'
 
-scikit_learn>=1.1.3     ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
-scikit_learn>=1.1.1     ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
+scikit_learn==1.1.3     ; python_version < '4.0'  and python_version >= '3.11'    # Python 3.11+
+scikit_learn==1.1.1     ; python_version < '3.11' and python_version >= '3.10'    # Python 3.10
 scikit-learn>=0.24.2    ; python_version < '3.10' and python_version >= '3.9'     # Python 3.9
 scikit-learn>=0.24.2    ; python_version < '3.9'  and python_version >= '3.8'     # Python 3.8
 

--- a/setup.py
+++ b/setup.py
@@ -281,7 +281,7 @@ if __name__ == "__main__":
     setupkw["package_dir"] = {
         "": "src/python",
     }
-
+    setupkw["cmake_args"] = []+ (['-GMSYS Makefiles' ] if os.name == 'nt' else [])
     ### <special non-xcookie generated code>
     setupkw['include_package_data'] = True
     setupkw['package_data'] = {

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def parse_description():
     readme_fpath = join(dirname(__file__), "README.rst")
     # This breaks on pip install, so check that it exists.
     if exists(readme_fpath):
-        with open(readme_fpath, "r") as f:
+        with open(readme_fpath, "r",encoding='utf-8') as f:
             text = f.read()
         return text
     return ""

--- a/src/cxx/CMakeLists.txt
+++ b/src/cxx/CMakeLists.txt
@@ -1,24 +1,25 @@
 option(BUILD_SCCD "Enable sccd c library" TRUE)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+
+# Find required external libraries
+find_package(Threads REQUIRED)
+find_package(ZLIB REQUIRED)
+find_package(GSL REQUIRED)
+
+enable_language(Fortran)
+# Corresponds to FFLAGS
+set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -fPIC")
+
+# Hacks:
+set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+
+add_library(GLMnet STATIC "GLMnet.f")
+
+set(SCCD_MODULE_NAME "sccd")
 if (BUILD_SCCD)
 
-  set(THREADS_PREFER_PTHREAD_FLAG ON)
-
-  # Find required external libraries
-  find_package(Threads REQUIRED)
-  find_package(ZLIB REQUIRED)
-  find_package(GSL REQUIRED)
-
-  # enable_language(Fortran)
-  # Corresponds to FFLAGS
-  set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -fPIC")
-
-  # Hacks:
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-  
-  add_library(GLMnet STATIC "GLMnet.f")
   # set_target_properties(GLMnet PROPERTIES LINKER_LANGUAGE Fortran)
 
-  set(SCCD_MODULE_NAME "sccd")
   # Add other C sources
   list(APPEND sccd_sources "cold.c" "input.c" "2d_array.c" "utilities.c" "misc.c" "multirobust.c" "output.c" "s_ccd.c" "KFAS.c" "lbfgs.c" "distribution_math.c")
   ## Create C++ library. Specify include dirs and link libs as normal
@@ -27,6 +28,34 @@ if (BUILD_SCCD)
   # HACK: statically link the library to the cython module because
   # I'm having trouble making the shared library work.
   add_library(${SCCD_MODULE_NAME} STATIC ${sccd_sources})
+
+  #target_compile_definitions(${SCCD_MODULE_NAME} PUBLIC
+  #  "NPY_NO_DEPRECATED_API"
+  #  #"NPY_1_7_API_VERSION=0x00000007"
+  #  )
+
+  # Transform the C++ library into an importable python module
+  #python_extension_module(${SCCD_MODULE_NAME})
+
+  # Install the C++ module to the correct relative location
+  # (this will be an inplace build if you use `pip install -e`)
+  #file(RELATIVE_PATH _install_dest "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
+  # Is this right?
+  #install(TARGETS ${SCCD_MODULE_NAME} LIBRARY DESTINATION "${_install_dest}../tool/python/pycold")
+
+else()  # build standalone program that accepts csv as input, mainly for testing purpose
+
+  set(CMAKE_BUILD_TYPE Debug)
+
+  set_target_properties(GLMnet PROPERTIES LINKER_LANGUAGE Fortran)
+
+  # Add other C sources
+  list(APPEND sccd_sources "cold.c" "input.c" "2d_array.c" "utilities.c" "misc.c" "multirobust.c" "output.c" "s_ccd.c" "KFAS.c" "lbfgs.c" "distribution_math.c" "sccd-desktop.c")
+  ## Create C++ library. Specify include dirs and link libs as normal
+
+  add_executable(${SCCD_MODULE_NAME} ${sccd_sources})
+
+endif()
 
   #target_include_directories(
   #  ${SCCD_MODULE_NAME}
@@ -49,70 +78,3 @@ if (BUILD_SCCD)
     GSL::gslcblas
     GLMnet
   )
-
-  #target_compile_definitions(${SCCD_MODULE_NAME} PUBLIC
-  #  "NPY_NO_DEPRECATED_API"
-  #  #"NPY_1_7_API_VERSION=0x00000007"
-  #  )
-
-  # Transform the C++ library into an importable python module
-  #python_extension_module(${SCCD_MODULE_NAME})
-
-  # Install the C++ module to the correct relative location
-  # (this will be an inplace build if you use `pip install -e`)
-  #file(RELATIVE_PATH _install_dest "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
-  # Is this right?
-  #install(TARGETS ${SCCD_MODULE_NAME} LIBRARY DESTINATION "${_install_dest}../tool/python/pycold")
-
-else()  # build standalone program that accepts csv as input, mainly for testing purpose
-  set(THREADS_PREFER_PTHREAD_FLAG ON)
-
-  # Find required external libraries
-  find_package(Threads REQUIRED)
-  find_package(ZLIB REQUIRED)
-  find_package(GSL REQUIRED)
-
-  enable_language(Fortran)
-
-  set(CMAKE_BUILD_TYPE Debug)
-
-  # Corresponds to FFLAGS
-  set (CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -fPIC")
-
-  # Hacks:
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-  
-  add_library(GLMnet STATIC "GLMnet.f")
-  set_target_properties(GLMnet PROPERTIES LINKER_LANGUAGE Fortran)
-
-  
-  set(SCCD_MODULE_NAME "cold")
-  # Add other C sources
-  list(APPEND sccd_sources "cold.c" "input.c" "2d_array.c" "utilities.c" "misc.c" "multirobust.c" "output.c" "s_ccd.c" "KFAS.c" "lbfgs.c" "distribution_math.c" "sccd-desktop.c")
-  ## Create C++ library. Specify include dirs and link libs as normal
-
-  add_executable(${SCCD_MODULE_NAME} ${sccd_sources})
-
-  #target_include_directories(
-  #  ${SCCD_MODULE_NAME}
-  #  PUBLIC
-  #      ${NumPy_INCLUDE_DIRS}
-  #      ${PYTHON_INCLUDE_DIRS}
-  #      ${CMAKE_CURRENT_SOURCE_DIR}
-  #)
-
-  #message(STATUS "ZLIB::ZLIB = ${ZLIB::ZLIB}")
-  #message(STATUS "Threads::Threads = ${Threads::Threads}")
-  message(STATUS "Threads = ${Threads}")
-
-  # LIB = -L$(GSL_SCI_LIB) -lz -lpthread -lgsl -lgslcblas -lgfortran -lm
-  target_link_libraries(
-    ${SCCD_MODULE_NAME} PUBLIC
-    ZLIB::ZLIB
-    Threads::Threads
-    GSL::gsl
-    GSL::gslcblas
-    GLMnet
-  )
-endif()
-

--- a/src/cxx/CMakeLists.txt
+++ b/src/cxx/CMakeLists.txt
@@ -4,6 +4,9 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 # Find required external libraries
 find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
+if(WIN32)
+  set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+endif()
 find_package(GSL REQUIRED)
 
 enable_language(Fortran)
@@ -57,24 +60,24 @@ else()  # build standalone program that accepts csv as input, mainly for testing
 
 endif()
 
-  #target_include_directories(
-  #  ${SCCD_MODULE_NAME}
-  #  PUBLIC
-  #      ${NumPy_INCLUDE_DIRS}
-  #      ${PYTHON_INCLUDE_DIRS}
-  #      ${CMAKE_CURRENT_SOURCE_DIR}
-  #)
+#target_include_directories(
+#  ${SCCD_MODULE_NAME}
+#  PUBLIC
+#      ${NumPy_INCLUDE_DIRS}
+#      ${PYTHON_INCLUDE_DIRS}
+#      ${CMAKE_CURRENT_SOURCE_DIR}
+#)
 
-  #message(STATUS "ZLIB::ZLIB = ${ZLIB::ZLIB}")
-  #message(STATUS "Threads::Threads = ${Threads::Threads}")
-  message(STATUS "Threads = ${Threads}")
+#message(STATUS "ZLIB::ZLIB = ${ZLIB::ZLIB}")
+#message(STATUS "Threads::Threads = ${Threads::Threads}")
+message(STATUS "Threads = ${Threads}")
 
- # LIB = -L$(GSL_SCI_LIB) -lz -lpthread -lgsl -lgslcblas -lgfortran -lm
-  target_link_libraries(
-    ${SCCD_MODULE_NAME} PUBLIC
-    ZLIB::ZLIB
-    Threads::Threads
-    GSL::gsl
-    GSL::gslcblas
-    GLMnet
-  )
+# LIB = -L$(GSL_SCI_LIB) -lz -lpthread -lgsl -lgslcblas -lgfortran -lm
+target_link_libraries(
+  ${SCCD_MODULE_NAME} PUBLIC
+  ZLIB::ZLIB
+  Threads::Threads
+  GSL::gsl
+  GSL::gslcblas
+  GLMnet
+)

--- a/src/cxx/cold.c
+++ b/src/cxx/cold.c
@@ -1,3 +1,4 @@
+#include<stdint.h>
 #include <string.h>
 #include <stdarg.h>
 #include <time.h>
@@ -51,7 +52,7 @@ int getlabelfromNLCD(int maskval){
         return NA_VALUE;
 }
 
-long getMicrotime(){
+int64_t getMicrotime(){
     struct timeval currentTime;
     gettimeofday(&currentTime, NULL);
     return currentTime.tv_sec * (int)1e6 + currentTime.tv_usec;
@@ -83,15 +84,15 @@ Date        Programmer       Reason
 ******************************************************************************/
 int cold
 (
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,       /* I:  the time series of cfmask values. 0 - clear; 1 - water; 2 - shadow; 3 - snow; 4 - cloud  */
-    long *valid_date_array,      /* I:  valid date as matlab serial date form (counting from Jan 0, 0000). Note ordinal date in python is from (Jan 1th, 0001) */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,       /* I:  the time series of cfmask values. 0 - clear; 1 - water; 2 - shadow; 3 - snow; 4 - cloud  */
+    int64_t *valid_date_array,      /* I:  valid date as matlab serial date form (counting from Jan 0, 0000). Note ordinal date in python is from (Jan 1th, 0001) */
     int valid_num_scenes,       /* I: number of valid scenes  */
     int pos,                     /* I: the position id of pixel */
     double tcg,                 /* I: threshold of change threshold  */
@@ -228,15 +229,15 @@ Date        Programmer       Reason
 int stand_procedure_fixeddays
 (
     int valid_num_scenes,             /* I:  number of valid scenes  */
-    long *valid_date_array,            /* I: valid date time series  */
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,       /* I:  mask-based time series  */
+    int64_t *valid_date_array,            /* I: valid date time series  */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,       /* I:  mask-based time series  */
     int *id_range,
     double tcg,                 /* I: threshold of change threshold  */
     int conse,                  /* I: consecutive observation number   */
@@ -2604,15 +2605,15 @@ Date        Programmer       Reason
 int stand_procedure
 (
     int valid_num_scenes,             /* I:  number of valid scenes  */
-    long *valid_date_array,            /* I: valid date time series  */
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,       /* I:  mask-based time series  */
+    int64_t *valid_date_array,            /* I: valid date time series  */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,       /* I:  mask-based time series  */
     int *id_range,
     double tcg,                 /* I: threshold of change threshold  */
     int conse,                  /* I: consecutive observation number   */
@@ -4846,15 +4847,15 @@ Date        Programmer       Reason
 int inefficientobs_procedure
 (
     int valid_num_scenes,             /* I:  number of scenes  */
-    long *valid_date_array,    /* I: valid date time series  */
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,      /* I:  mask-based time series  */
+    int64_t *valid_date_array,    /* I: valid date time series  */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,      /* I:  mask-based time series  */
     int *id_range,
     float sn_pct,
     Output_t *rec_cg,
@@ -5365,17 +5366,17 @@ Date        Programmer       Reason
 ******************************************************************************/
 int obcold_reconstruction_procedure
 (
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,       /* I:  the time series of cfmask values. 0 - clear; 1 - water; 2 - shadow; 3 - snow; 4 - cloud  */
-    long *valid_date_array,      /* I:  valid date as matlab serial date form (counting from Jan 0, 0000). Note ordinal date in python is from (Jan 1th, 0001) */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,       /* I:  the time series of cfmask values. 0 - clear; 1 - water; 2 - shadow; 3 - snow; 4 - cloud  */
+    int64_t *valid_date_array,      /* I:  valid date as matlab serial date form (counting from Jan 0, 0000). Note ordinal date in python is from (Jan 1th, 0001) */
     int valid_num_scenes,       /* I: number of valid scenes  */
-    long *break_dates, /*an array of break dates with a fixed length of num_year, '0' means no breaks */
+    int64_t *break_dates, /*an array of break dates with a fixed length of num_year, '0' means no breaks */
     int break_date_len,       /*I: the length of break_dates */
     int pos,              /*I: the position of the pixel */
     bool b_c2,                  /* I: a temporal parameter to indicate if collection 2. C2 needs ignoring thermal band due to the current low quality  */

--- a/src/cxx/cold.h
+++ b/src/cxx/cold.h
@@ -1,20 +1,21 @@
 #ifndef CCD_H
 #define CCD_H
+#include<stdint.h>
 #include <stdbool.h>
 #include "output.h"
 // #include <xgboost/c_api.h>
 
 int cold
 (
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,       /* I:  the time series of cfmask values. 0 - clear; 1 - water; 2 - shadow; 3 - snow; 4 - cloud  */
-    long *valid_date_array,      /* I:  valid date as matlab serial date form (counting from Jan 0, 0000). Note ordinal date in python is from (Jan 1th, 0001) */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,       /* I:  the time series of cfmask values. 0 - clear; 1 - water; 2 - shadow; 3 - snow; 4 - cloud  */
+    int64_t *valid_date_array,      /* I:  valid date as matlab serial date form (counting from Jan 0, 0000). Note ordinal date in python is from (Jan 1th, 0001) */
     int valid_num_scenes,       /* I: number of valid scenes  */
     int pos,                     /* I: the position id of pixel */
     double tcg,                 /* I: threshold of change threshold  */
@@ -34,15 +35,15 @@ int cold
 int stand_procedure
 (
     int valid_num_scenes,             /* I:  number of valid scenes  */
-    long *valid_date_array,            /* I: valid date time series  */
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,       /* I:  mask-based time series  */
+    int64_t *valid_date_array,            /* I: valid date time series  */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,       /* I:  mask-based time series  */
     int *id_range,
     double tcg,                 /* I: threshold of change threshold  */
     int conse,                  /* I: consecutive observation number   */
@@ -60,15 +61,15 @@ int stand_procedure
 int inefficientobs_procedure
 (
     int valid_num_scenes,             /* I:  number of scenes  */
-    long *valid_date_array,    /* I: valid date time series  */
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,      /* I:  mask-based time series  */
+    int64_t *valid_date_array,    /* I: valid date time series  */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,      /* I:  mask-based time series  */
     int *id_range,
     float sn_pct,
     Output_t *rec_cg,
@@ -80,17 +81,17 @@ int inefficientobs_procedure
 
 int obcold_reconstruction_procedure
 (
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,       /* I:  the time series of cfmask values. 0 - clear; 1 - water; 2 - shadow; 3 - snow; 4 - cloud  */
-    long *valid_date_array,      /* I:  valid date as matlab serial date form (counting from Jan 0, 0000). Note ordinal date in python is from (Jan 1th, 0001) */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,       /* I:  the time series of cfmask values. 0 - clear; 1 - water; 2 - shadow; 3 - snow; 4 - cloud  */
+    int64_t *valid_date_array,      /* I:  valid date as matlab serial date form (counting from Jan 0, 0000). Note ordinal date in python is from (Jan 1th, 0001) */
     int valid_num_scenes,       /* I: number of valid scenes  */
-    long *break_dates, /*an array of break dates with a fixed length of num_year, '0' means no breaks */
+    int64_t *break_dates, /*an array of break dates with a fixed length of num_year, '0' means no breaks */
     int break_date_len,       /*I: the number of focused years */
     int pos,              /*I: the position of the pixel */
     bool b_c2,                  /* I: a temporal parameter to indicate if collection 2. C2 needs ignoring thermal band due to the current low quality  */
@@ -110,15 +111,15 @@ double angle_decaying(
 int stand_procedure_fixeddays
 (
     int valid_num_scenes,             /* I:  number of valid scenes  */
-    long *valid_date_array,            /* I: valid date time series  */
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,       /* I:  mask-based time series  */
+    int64_t *valid_date_array,            /* I: valid date time series  */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,       /* I:  mask-based time series  */
     int *id_range,
     double tcg,                 /* I: threshold of change threshold  */
     int conse,                  /* I: consecutive observation number   */

--- a/src/cxx/cold_norecoverybreak.c
+++ b/src/cxx/cold_norecoverybreak.c
@@ -1,3 +1,4 @@
+#include<stdint.h>
 #include <string.h>
 #include <stdarg.h>
 #include <time.h>
@@ -52,7 +53,7 @@ int getlabelfromNLCD(int maskval){
         return NA_VALUE;
 }
 
-long getMicrotime(){
+int64_t getMicrotime(){
     struct timeval currentTime;
     gettimeofday(&currentTime, NULL);
     return currentTime.tv_sec * (int)1e6 + currentTime.tv_usec;
@@ -194,8 +195,8 @@ const char *check_parameter(int mode,char* in_path,char* out_path,int n_cores,
 //    Output_t*  rec_cg;                 /* CCDC outputted recorded  */
 //    int block_num;
 //    //block_num = (int)meta->lines / threads;
-//    long ms_start = getMicrotime();
-//    long ms_end;
+//    int64_t ms_start = getMicrotime();
+//    int64_t ms_end;
 //    char states_output_dir[MAX_STR_LEN];
 //    FILE *sampleFile;
 //    int pixel_qa;
@@ -4406,7 +4407,7 @@ int ccd_scanline
         valid_scene_count_scanline[i] = 0;
     }
 
-//    long ms_start = getMicrotime();
+//    int64_t ms_start = getMicrotime();
 //    if(format == ENVI_FORMAT)
     result = read_bip_lines(in_path, scene_list, row, num_samples, num_scenes, sdate, buf,
                             fmask_buf_scanline, valid_scene_count_scanline,valid_date_array_scanline,
@@ -4419,7 +4420,7 @@ int ccd_scanline
 //                                fmask_buf_scanline, valid_scene_count_scanline, valid_date_array_scanline,
 //                                sensor_buf);
 
-//    long ms_end = getMicrotime();
+//    int64_t ms_end = getMicrotime();
 //    char msg_str[MAX_STR_LEN];       /* Input data scene name                 */
 //    snprintf (msg_str, sizeof(msg_str), "CCDC reading scanline time (in ms)=%ld\n", ms_end - ms_start);
 //    LOG_MESSAGE (msg_str, FUNC_NAME);

--- a/src/cxx/misc.c
+++ b/src/cxx/misc.c
@@ -2,7 +2,7 @@
 #include <stdarg.h>
 #include <math.h>
 #include <dirent.h>
-#include <fnmatch.h>
+// #include <fnmatch.h>
 #include <string.h>
 #include <limits.h>
 #include <errno.h>

--- a/src/cxx/s_ccd.c
+++ b/src/cxx/s_ccd.c
@@ -1,4 +1,5 @@
-﻿#include <gsl/gsl_blas.h>
+﻿#include<stdint.h>
+#include <gsl/gsl_blas.h>
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_matrix.h>
 #include "math.h"
@@ -31,15 +32,15 @@ Date        Programmer       Reason
 04/14/2022   Su Ye         update
 ******************************************************************************/
 int sccd(
-    long *buf_b,                /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,                /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,                /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,                /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,               /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,               /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,                /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,            /* I:  mask-based time series              */
-    long *valid_date_array,     /* I: valid date time series               */
+    int64_t *buf_b,                /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,                /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,                /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,                /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,               /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,               /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,                /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,            /* I:  mask-based time series              */
+    int64_t *valid_date_array,     /* I: valid date time series               */
     int valid_num_scenes,       /* I: number of valid scenes under cfmask fill counts  */
     double tcg,                 /* I: the change threshold  */
     int *num_fc,                /* O: number of fitting curves                       */

--- a/src/cxx/s_ccd.h
+++ b/src/cxx/s_ccd.h
@@ -2,21 +2,22 @@
 #define CCD_STOCHASTIC_H
 
 #endif // CCD_STOCHASTIC_H
+#include<stdint.h>
 #include "KFAS.h"
 #include "output.h"
 
 
 int sccd
 (
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,       /* I:  mask-based time series              */
-    long *valid_date_array,      /* I: valid date time series               */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,       /* I:  mask-based time series              */
+    int64_t *valid_date_array,      /* I: valid date time series               */
     int valid_num_scenes,       /* I: number of valid scenes under cfmask fill counts  */
     double tcg,                /* I: the change threshold  */
     int *num_fc,                /* O: number of fitting curves                       */

--- a/src/cxx/sccd-desktop.c
+++ b/src/cxx/sccd-desktop.c
@@ -1,3 +1,4 @@
+#include<stdint.h>
 #include <string.h>
 #include <stdarg.h>
 #include <time.h>
@@ -249,7 +250,7 @@ int main(int argc, char *argv[])
     int status;                      /* Return value from function call       */
     char FUNC_NAME[] = "main";       /* For printing error messages           */
 
-    long *sdate;                      /* Pointer to list of acquisition dates  */
+    int64_t *sdate;                      /* Pointer to list of acquisition dates  */
     char **scene_list;                /* 2-D array for list of scene IDs       */
 
     int num_scenes;                  /* Number of input scenes defined        */
@@ -265,8 +266,8 @@ int main(int argc, char *argv[])
     /**************************************************************************/
 
 
-    long *fmask_buf;        /* fmask buf, valid pixels only*/
-    long **buf;                       /* This is the image bands buffer, valid pixel only*/
+    int64_t *fmask_buf;        /* fmask buf, valid pixels only*/
+    int64_t **buf;                       /* This is the image bands buffer, valid pixel only*/
     // int n_working_process; /* total processes - 1 (master process)*/
     int i_col;
     FILE *fhoutput;
@@ -277,7 +278,7 @@ int main(int argc, char *argv[])
     //int *tmp_valid_date_array;             /* Sdate array after cfmask filtering    */
     Output_t* rec_cg;
     Output_sccd* s_rec_cg;
-    long *sensor_buf;
+    int64_t *sensor_buf;
     double tcg;
     int n_cm_maps = 0;
     short int* CM_outputs;
@@ -285,7 +286,7 @@ int main(int argc, char *argv[])
     unsigned char* CMdirection_outputs;
     // bool b_singleline = FALSE;
     int num_breakdatemaps;
-    long *breakdates_block;
+    int64_t *breakdates_block;
     // int sample_row = 0;
     // int sample_col = 0;
 
@@ -416,27 +417,27 @@ int main(int argc, char *argv[])
     /* memory for date array.                                     */
     /*                                                            */
     /**************************************************************/
-    sdate = (long *)malloc(num_scenes * sizeof(long));
+    sdate = (int64_t *)malloc(num_scenes * sizeof(int64_t));
 
     if (sdate == NULL)
     {
         RETURN_ERROR("ERROR allocating sdate memory", FUNC_NAME, FAILURE);
     }
 
-    buf = (long **) allocate_2d_array (TOTAL_IMAGE_BANDS, MAX_SCENE_LIST, sizeof (long));
+    buf = (int64_t **) allocate_2d_array (TOTAL_IMAGE_BANDS, MAX_SCENE_LIST, sizeof (int64_t));
     if(buf == NULL)
     {
         RETURN_ERROR ("Allocating buf", FUNC_NAME, FAILURE);
     }
 
 
-    fmask_buf = (long *) malloc(num_scenes * sizeof(long));
+    fmask_buf = (int64_t *) malloc(num_scenes * sizeof(int64_t));
     if(fmask_buf == NULL)
     {
         RETURN_ERROR ("Allocating fmask_buf", FUNC_NAME, FAILURE);
     }
 
-    sensor_buf = (long *) malloc(MAX_SCENE_LIST * sizeof (long));
+    sensor_buf = (int64_t *) malloc(MAX_SCENE_LIST * sizeof (int64_t));
     if(sensor_buf  == NULL)
     {
         RETURN_ERROR ("Allocating sensor_buf ", FUNC_NAME, FAILURE);
@@ -457,13 +458,13 @@ int main(int argc, char *argv[])
         if(row_count != headline) // we skip first line because it is a header
         {
             sdate[valid_scene_count] = atoi(strtok(csv_row, ","));
-            buf[0][valid_scene_count] = (long)atoi(strtok(NULL, ","));
-            buf[1][valid_scene_count] = (long)atoi(strtok(NULL, ","));
-            buf[2][valid_scene_count] = (long)atoi(strtok(NULL, ","));
-            buf[3][valid_scene_count] = (long)atoi(strtok(NULL, ","));
-            buf[4][valid_scene_count] = (long)atoi(strtok(NULL, ","));
-            buf[5][valid_scene_count] = (long)atoi(strtok(NULL, ","));
-            buf[6][valid_scene_count] = (long)atoi(strtok(NULL, ","));
+            buf[0][valid_scene_count] = (int64_t)atoi(strtok(NULL, ","));
+            buf[1][valid_scene_count] = (int64_t)atoi(strtok(NULL, ","));
+            buf[2][valid_scene_count] = (int64_t)atoi(strtok(NULL, ","));
+            buf[3][valid_scene_count] = (int64_t)atoi(strtok(NULL, ","));
+            buf[4][valid_scene_count] = (int64_t)atoi(strtok(NULL, ","));
+            buf[5][valid_scene_count] = (int64_t)atoi(strtok(NULL, ","));
+            buf[6][valid_scene_count] = (int64_t)atoi(strtok(NULL, ","));
             pixel_qa = atoi(strtok(NULL, ","));
     //                if (training_type == 1)
     //                {
@@ -473,7 +474,7 @@ int main(int argc, char *argv[])
     //                else
     //                   fmask_buf[valid_scene_count] = (short)qabitval(pixel_qa);
             //fmask_buf[valid_scene_count] = (short)qabitval(pixel_qa);
-            fmask_buf[valid_scene_count] = (long)pixel_qa;
+            fmask_buf[valid_scene_count] = (int64_t)pixel_qa;
             // sensor_buf[valid_scene_count] = (short)atoi(strtok(NULL, ","));
 
             valid_scene_count++;
@@ -558,7 +559,7 @@ int main(int argc, char *argv[])
     if(b_obcold_reconstruction == TRUE)
     {
 
-        breakdates_block = malloc(MAX_YEAR_RANGE * sizeof (long));
+        breakdates_block = malloc(MAX_YEAR_RANGE * sizeof (int64_t));
         if(breakdates_block == NULL)
         {
             RETURN_ERROR ("Allocating breakdates_block", FUNC_NAME, FAILURE);

--- a/src/cxx/utilities.c
+++ b/src/cxx/utilities.c
@@ -1,3 +1,4 @@
+#include<stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <errno.h>
@@ -236,7 +237,7 @@ void quick_sort_double(double arr[], int left, int right)
 /******************************************************************************
 MODULE:  quick_sort_long
 
-PURPOSE:  sort the long data array based on yeardoy string
+PURPOSE:  sort the int64_t data array based on yeardoy string
 
 RETURN VALUE: None
 
@@ -247,7 +248,7 @@ Date        Programmer       Reason
 
 NOTES:
 ******************************************************************************/
-void quick_sort_long(long arr[], int left, int right)
+void quick_sort_long(int64_t arr[], int left, int right)
 {
     int index = partition_long (arr, left, right);
 
@@ -618,11 +619,11 @@ Date        Programmer       Reason
 
 NOTES:
 ******************************************************************************/
-int partition_long (long arr[], int left, int right)
+int partition_long (int64_t arr[], int left, int right)
 {
     int i = left, j = right;
-    long tmp;
-    long pivot = arr[(left + right) / 2];
+    int64_t tmp;
+    int64_t pivot = arr[(left + right) / 2];
 
     while (i <= j)
     {
@@ -902,7 +903,7 @@ Date        Programmer       Reason
 //    while (1)
 //    {
 //        /* optstring in call to getopt_long is empty since we will only
-//           support the long options */
+//           support the int64_t options */
 //        c = getopt_long (argc, argv, "", long_options, &option_index);
 //        if (c == -1)
 //        {
@@ -1156,14 +1157,14 @@ Date        Programmer       Reason
 
 int preprocessing
 (
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,        /* I:   mask time series  */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,        /* I:   mask time series  */
     int *valid_num_scenes, /* I/O: * number of scenes after cfmask counts and  */
     int *id_range,
     int *clear_sum,      /* I/O: Total number of clear cfmask pixels          */
@@ -1176,7 +1177,7 @@ int preprocessing
 {
 
     int i;
-    long buf_t_tmp ;
+    int64_t buf_t_tmp ;
 
     for (i = 0; i < *valid_num_scenes; i++)
     {
@@ -1185,7 +1186,7 @@ int preprocessing
             if(b_c2 == TRUE)
                buf_t_tmp = 0;
             else
-               buf_t_tmp = (long)(buf_t[i] * 10 - 27320);
+               buf_t_tmp = (int64_t)(buf_t[i] * 10 - 27320);
         }else{
             buf_t_tmp = 0;
         }

--- a/src/cxx/utilities.h
+++ b/src/cxx/utilities.h
@@ -1,6 +1,7 @@
 #ifndef UTILITIES_H
 #define UTILITIES_H
 
+#include<stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
 
@@ -55,10 +56,10 @@ void quick_sort(int arr[], char *brr[], int crr[], int left, int right);
 int partition(int arr[], char *brr[], int crr[], int left, int right);
 void quick_sort_float(float arr[], int left, int right);
 void quick_sort_double(double arr[], int left, int right);
-void quick_sort_long(long arr[], int left, int right);
+void quick_sort_long(int64_t arr[], int left, int right);
 int partition_float (float arr[], int left, int right);
 int partition_double (double arr[], int left, int right);
-int partition_long (long arr[], int left, int right);
+int partition_long (int64_t arr[], int left, int right);
 int partition_index (int arr[],  int *index, int left, int right);
 void quick_sort_buf (int arr[], short int **brr, short int *fmask_buf, int left, int right);
 void quick_sort_index (int arr[], int *index,  int left, int right);
@@ -114,14 +115,14 @@ int usage_message ();
 
 int preprocessing
 (
-    long *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
-    long *fmask_buf,        /* I:   mask time series  */
+    int64_t *buf_b,            /* I:  Landsat blue spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_g,            /* I:  Landsat green spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_r,            /* I:  Landsat red spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_n,            /* I:  Landsat NIR spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s1,           /* I:  Landsat swir1 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_s2,           /* I:  Landsat swir2 spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *buf_t,            /* I:  Landsat thermal spectral time series.The dimension is (n_obs, 7). Invalid (qa is filled value (255)) must be removed */
+    int64_t *fmask_buf,        /* I:   mask time series  */
     int *valid_num_scenes, /* I/O: * number of scenes after cfmask counts and  */
     int *id_range,
     int *clear_sum,      /* I/O: Total number of clear cfmask pixels          */

--- a/src/python/pycold/CMakeLists.txt
+++ b/src/python/pycold/CMakeLists.txt
@@ -27,8 +27,11 @@ if (BUILD_PYCOLD)
   set(SCCD_MODULE_NAME "sccd")
 
   # TODO: linking to the SCCD shared object isn't working 100% yet.
-  target_link_libraries(${PYCOLD_MODULE_NAME} ${SCCD_MODULE_NAME})
 
+
+  target_link_libraries(${PYCOLD_MODULE_NAME} ${SCCD_MODULE_NAME} GLMnet)
+  
+  
   target_compile_definitions(${PYCOLD_MODULE_NAME} PUBLIC
     "NPY_NO_DEPRECATED_API"
     #"NPY_1_7_API_VERSION=0x00000007"
@@ -36,11 +39,52 @@ if (BUILD_PYCOLD)
 
   # Transform the C++ library into an importable python module
   python_extension_module(${PYCOLD_MODULE_NAME})
+  if(WIN32)  
+    if(MSYS)
+      message(STATUS "MSYS2 detected")
+    else()# display error and exit
+      message(FATAL_ERROR "Currently only MSYS2 is supported for Windows builds.")
+    endif()
 
+    target_compile_definitions(${PYCOLD_MODULE_NAME} PRIVATE MS_WIN64=1)# if on windows, add compile definition MS_WIN64=1
+    set_target_properties(${SCCD_MODULE_NAME} PROPERTIES INTERFACE_LINK_LIBRARIES "")
+    # print LINK_LIBRARIES of target ${PYCOLD_MODULE_NAME}
+
+
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})# force use static libs, e.g. libxx.a rather than libxx.dll.a
+    find_library(gfortran NAMES gfortran REQUIRED)
+    find_library(winpthread NAMES winpthread REQUIRED)
+    find_library(quadmath NAMES quadmath REQUIRED)
+    find_package(GSL REQUIRED)
+    target_link_libraries(${PYCOLD_MODULE_NAME}
+    # -Wl,-Bstatic
+    ${gfortran} 
+    ${winpthread}
+    ${quadmath}
+    GSL::gsl
+    GSL::gslcblas
+    -static-libgcc
+    ) 
+
+    # HACK: There's no way to remove -lgcc_s inside CMake, so we need to modify it manually
+    # Define the path to the linkLibs.rsp file
+    set(LINKLIBS_RSP_FILE "${CMAKE_BINARY_DIR}/src/python/pycold/CMakeFiles/${PYCOLD_MODULE_NAME}.dir/linkLibs.rsp")
+
+    # # Custom command to remove -lgcc_s from linkLibs.rsp using sed
+    add_custom_command(
+        TARGET ${PYCOLD_MODULE_NAME}
+        PRE_LINK
+        COMMAND sed -i "s/-lgcc_s//g" ${LINKLIBS_RSP_FILE} 
+        COMMAND ${CMAKE_COMMAND} -E echo "after removing:"       
+        COMMAND ${CMAKE_COMMAND} -E cat ${LINKLIBS_RSP_FILE}
+        COMMENT "Removing -lgcc_s from ${TARGET_NAME} linkLibs.rsp"
+    )
+
+  endif()
+  
   # Install the C++ module to the correct relative location
   # (this will be an inplace build if you use `pip install -e`)
   #file(RELATIVE_PATH pycold_install_dest "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}")
-
 
   # My "normal" method of setting install targets does not seem to work here. Hacking it.
   # NOTE: skbuild *seems* to place libraries in a data dir *unless* the install destination

--- a/src/python/pycold/_colds_cython.pyx
+++ b/src/python/pycold/_colds_cython.pyx
@@ -10,6 +10,8 @@ from libcpp cimport bool
 from collections import namedtuple
 from copy import deepcopy
 cimport cython
+from libc.stdint cimport int32_t, int64_t, uint32_t, uint64_t
+# instead of int32_t and int64_t for cross-platform compatibility,see https://github.com/ansys/pymapdl/issues/14
 from cpython.mem cimport PyMem_Malloc, PyMem_Realloc, PyMem_Free
 from .common import reccg_dt, sccd_dt, nrtqueue_dt, nrtmodel_dt, pinpoint_dt
 np.import_array()
@@ -20,9 +22,9 @@ try:
 except ImportError:
     pass  # The modules don't actually have to exists for Cython to use them as annotations
 
-cdef int NUM_FC = 40  # define the maximum number of outputted curves
-cdef int NUM_FC_SCCD = 40
-cdef int NUM_NRT_QUEUE = 240
+cdef int32_t NUM_FC = 40  # define the maximum number of outputted curves
+cdef int32_t NUM_FC_SCCD = 40
+cdef int32_t NUM_NRT_QUEUE = 240
 DEF DEFAULT_CONSE = 8
 DEF NRT_BAND = 6
 DEF SCCD_NUM_C = 6
@@ -30,11 +32,11 @@ DEF SCCD_NUM_C = 6
 
 cdef extern from "../../cxx/output.h":
     ctypedef struct Output_t:
-        int t_start
-        int t_end
-        int t_break
-        int pos
-        int num_obs
+        int32_t t_start
+        int32_t t_end
+        int32_t t_break
+        int32_t pos
+        int32_t num_obs
         short int category
         short int change_prob
         float coefs[7][8]
@@ -43,9 +45,9 @@ cdef extern from "../../cxx/output.h":
 
 cdef extern from "../../cxx/output.h":
     ctypedef struct Output_sccd:
-        int t_start
-        int t_break
-        int num_obs
+        int32_t t_start
+        int32_t t_break
+        int32_t num_obs
         float coefs[NRT_BAND][SCCD_NUM_C]
         float rmse[NRT_BAND]
         float magnitude[NRT_BAND]
@@ -64,14 +66,14 @@ cdef extern from "../../cxx/output.h":
         float covariance[NRT_BAND][36]
         float nrt_coefs[NRT_BAND][SCCD_NUM_C]
         float H[NRT_BAND]
-        unsigned int rmse_sum[NRT_BAND]
+        uint32_t rmse_sum[NRT_BAND]
         short int norm_cm;
         short int cm_angle;
         unsigned char conse_last;
 
 cdef extern from "../../cxx/output.h":
     ctypedef struct Output_sccd_pinpoint:
-        int t_break
+        int32_t t_break
         float coefs[NRT_BAND][SCCD_NUM_C]
         short int obs[NRT_BAND][DEFAULT_CONSE]
         short int obs_date_since1982[DEFAULT_CONSE]
@@ -80,26 +82,26 @@ cdef extern from "../../cxx/output.h":
 
 
 cdef extern from "../../cxx/cold.h":
-    cdef int cold(long *buf_b, long *buf_g, long *buf_r, long *buf_n, long *buf_s1, long *buf_s2,
-                  long *buf_t, long *fmask_buf, long *valid_date_array, int valid_num_scenes, int pos, 
-                  double tcg, int conse, bool b_output_cm, int starting_date, bool b_c2, Output_t *rec_cg,
-                  int *num_fc, int cm_output_interval, short int *cm_outputs,
+    cdef int32_t cold(int64_t *buf_b, int64_t *buf_g, int64_t *buf_r, int64_t *buf_n, int64_t *buf_s1, int64_t *buf_s2,
+                  int64_t *buf_t, int64_t *fmask_buf, int64_t *valid_date_array, int32_t valid_num_scenes, int32_t pos, 
+                  double tcg, int32_t conse, bool b_output_cm, int32_t starting_date, bool b_c2, Output_t *rec_cg,
+                  int32_t *num_fc, int32_t cm_output_interval, short int *cm_outputs,
                   short int *cm_outputs_date, double gap_days);
 
 
 cdef extern from "../../cxx/cold.h":
-    cdef int obcold_reconstruction_procedure(long *buf_b, long *buf_g, long *buf_r, long *buf_n, long *buf_s1,
-    long *buf_s2, long *buf_t,  long *fmask_buf, long *valid_date_array, int valid_num_scenes, long *break_dates,
-    int break_date_len, int pos, bool b_c2, int conse, Output_t *rec_cg, int *num_fc)
+    cdef int32_t obcold_reconstruction_procedure(int64_t *buf_b, int64_t *buf_g, int64_t *buf_r, int64_t *buf_n, int64_t *buf_s1,
+    int64_t *buf_s2, int64_t *buf_t,  int64_t *fmask_buf, int64_t *valid_date_array, int32_t valid_num_scenes, int64_t *break_dates,
+    int32_t break_date_len, int32_t pos, bool b_c2, int32_t conse, Output_t *rec_cg, int32_t *num_fc)
 
 
 
 cdef extern from "../../cxx/s_ccd.h":
-    cdef int sccd(long *buf_b, long *buf_g, long *buf_r, long *buf_n, long *buf_s1, long *buf_s2, long *buf_t,
-                  long *fmask_buf, long *valid_date_array, int valid_num_scenes, double tcg, int *num_fc, int *nrt_mode,
-                  Output_sccd *rec_cg, output_nrtmodel *nrt_model, int *num_nrt_queue, output_nrtqueue *nrt_queue,
-                  short int *min_rmse, int conse, bool b_c2, bool b_pinpoint, Output_sccd_pinpoint *rec_cg_pinpoint, 
-                  int *num_fc_pinpoint, double gate_tcg, double predictability_tcg)
+    cdef int32_t sccd(int64_t *buf_b, int64_t *buf_g, int64_t *buf_r, int64_t *buf_n, int64_t *buf_s1, int64_t *buf_s2, int64_t *buf_t,
+                  int64_t *fmask_buf, int64_t *valid_date_array, int32_t valid_num_scenes, double tcg, int32_t *num_fc, int32_t *nrt_mode,
+                  Output_sccd *rec_cg, output_nrtmodel *nrt_model, int32_t *num_nrt_queue, output_nrtqueue *nrt_queue,
+                  short int *min_rmse, int32_t conse, bool b_c2, bool b_pinpoint, Output_sccd_pinpoint *rec_cg_pinpoint, 
+                  int32_t *num_fc_pinpoint, double gate_tcg, double predictability_tcg)
 
 
 
@@ -110,9 +112,9 @@ cdef Output_sccd_pinpoint t4
 
 
 #cdef class SccdOutput:
-#    cdef public int position
+#    cdef public int32_t position
 #    cdef public np.ndarray rec_cg
-#    cdef public int nrt_mode
+#    cdef public int32_t nrt_mode
 #    cdef public tuple nrt_model
 #    cdef public np.ndarray nrt_queue
 #    def __init__(self, position, rec_cg, nrt_mode, nrt_model, nrt_queue):
@@ -135,8 +137,8 @@ cpdef _cold_detect(np.ndarray[np.int64_t, ndim=1, mode='c'] dates, np.ndarray[np
                    np.ndarray[np.int64_t, ndim=1, mode='c'] ts_g, np.ndarray[np.int64_t, ndim=1, mode='c'] ts_r,
                    np.ndarray[np.int64_t, ndim=1, mode='c'] ts_n, np.ndarray[np.int64_t, ndim=1, mode='c'] ts_s1,
                    np.ndarray[np.int64_t, ndim=1, mode='c'] ts_s2, np.ndarray[np.int64_t, ndim=1, mode='c'] ts_t,
-                   np.ndarray[np.int64_t, ndim=1, mode='c'] qas, double t_cg = 15.0863, int pos=1, int conse=6,
-                   bint b_output_cm=False, int starting_date=0, int n_cm=0, int cm_output_interval=0, bint b_c2=True,
+                   np.ndarray[np.int64_t, ndim=1, mode='c'] qas, double t_cg = 15.0863, int32_t pos=1, int32_t conse=6,
+                   bint b_output_cm=False, int32_t starting_date=0, int32_t n_cm=0, int32_t cm_output_interval=0, bint b_c2=True,
                    double gap_days=365.25):
     """
     Helper function to do COLD algorithm.
@@ -168,21 +170,21 @@ cpdef _cold_detect(np.ndarray[np.int64_t, ndim=1, mode='c'] dates, np.ndarray[np
         change records: the COLD outputs that characterizes each temporal segment
     """
 
-    cdef int valid_num_scenes = qas.shape[0]
+    cdef int32_t valid_num_scenes = qas.shape[0]
     # allocate memory for rec_cg
-    cdef int num_fc = 0
+    cdef int32_t num_fc = 0
     cdef Output_t t
     rec_cg = np.zeros(NUM_FC, dtype=reccg_dt)
 
-    cdef long [:] dates_view = dates
-    cdef long [:] ts_b_view = ts_b
-    cdef long [:] ts_g_view = ts_g
-    cdef long [:] ts_r_view = ts_r
-    cdef long [:] ts_n_view = ts_n
-    cdef long [:] ts_s1_view = ts_s1
-    cdef long [:] ts_s2_view = ts_s2
-    cdef long [:] ts_t_view = ts_t
-    cdef long [:] qas_view = qas
+    cdef int64_t [:] dates_view = dates
+    cdef int64_t [:] ts_b_view = ts_b
+    cdef int64_t [:] ts_g_view = ts_g
+    cdef int64_t [:] ts_r_view = ts_r
+    cdef int64_t [:] ts_n_view = ts_n
+    cdef int64_t [:] ts_s1_view = ts_s1
+    cdef int64_t [:] ts_s2_view = ts_s2
+    cdef int64_t [:] ts_t_view = ts_t
+    cdef int64_t [:] qas_view = qas
     cdef Output_t [:] rec_cg_view = rec_cg
 
     # cm_outputs and cm_outputs_date are for object-based cold
@@ -228,8 +230,8 @@ cpdef _obcold_reconstruct(np.ndarray[np.int64_t, ndim=1, mode='c'] dates,
                           np.ndarray[np.int64_t, ndim=1, mode='c'] ts_s2,
                           np.ndarray[np.int64_t, ndim=1, mode='c'] ts_t,
                           np.ndarray[np.int64_t, ndim=1, mode='c'] qas,
-                          np.ndarray[np.int64_t, ndim=1, mode='c'] break_dates, int pos=1,
-                          int conse=6, bint b_c2=True):
+                          np.ndarray[np.int64_t, ndim=1, mode='c'] break_dates, int32_t pos=1,
+                          int32_t conse=6, bint b_c2=True):
     """
     re-contructructing change records using break dates.
         Parameters
@@ -253,23 +255,23 @@ cpdef _obcold_reconstruct(np.ndarray[np.int64_t, ndim=1, mode='c'] dates,
         change records: the COLD outputs that characterizes each temporal segment
     """
 
-    cdef int valid_num_scenes = qas.shape[0]
-    cdef int break_date_len = break_dates.shape[0]
+    cdef int32_t valid_num_scenes = qas.shape[0]
+    cdef int32_t break_date_len = break_dates.shape[0]
     # allocate memory for rec_cg
-    cdef int num_fc = 0
+    cdef int32_t num_fc = 0
     cdef Output_t t
     rec_cg = np.zeros(NUM_FC, dtype=reccg_dt)
 
-    cdef long [:] dates_view = dates
-    cdef long [:] ts_b_view = ts_b
-    cdef long [:] ts_g_view = ts_g
-    cdef long [:] ts_r_view = ts_r
-    cdef long [:] ts_n_view = ts_n
-    cdef long [:] ts_s1_view = ts_s1
-    cdef long [:] ts_s2_view = ts_s2
-    cdef long [:] ts_t_view = ts_t
-    cdef long [:] qas_view = qas
-    cdef long [:] break_dates_view = break_dates
+    cdef int64_t [:] dates_view = dates
+    cdef int64_t [:] ts_b_view = ts_b
+    cdef int64_t [:] ts_g_view = ts_g
+    cdef int64_t [:] ts_r_view = ts_r
+    cdef int64_t [:] ts_n_view = ts_n
+    cdef int64_t [:] ts_s1_view = ts_s1
+    cdef int64_t [:] ts_s2_view = ts_s2
+    cdef int64_t [:] ts_t_view = ts_t
+    cdef int64_t [:] qas_view = qas
+    cdef int64_t [:] break_dates_view = break_dates
     cdef Output_t [:] rec_cg_view = rec_cg
 
     result = obcold_reconstruction_procedure(&ts_b_view[0], &ts_g_view[0], &ts_r_view[0], &ts_n_view[0], &ts_s1_view[0],
@@ -293,7 +295,7 @@ cpdef _sccd_detect(np.ndarray[np.int64_t, ndim=1, mode='c'] dates,
                    np.ndarray[np.int64_t, ndim=1, mode='c'] ts_s2,
                    np.ndarray[np.int64_t, ndim=1, mode='c'] ts_t,
                    np.ndarray[np.int64_t, ndim=1, mode='c'] qas,
-                   double t_cg = 15.0863, int pos=1, int conse=6, bint b_c2=True, b_pinpoint=False,
+                   double t_cg = 15.0863, int32_t pos=1, int32_t conse=6, bint b_c2=True, b_pinpoint=False,
                    double gate_tcg=9.236, double predictability_tcg=9.236):
     """
     S-CCD processing. It is required to be done before near real time monitoring
@@ -323,7 +325,7 @@ cpdef _sccd_detect(np.ndarray[np.int64_t, ndim=1, mode='c'] dates,
             change records: the S-CCD outputs that characterizes each temporal segment
             rec_cg:
             min_rmse
-            int nrt_mode,             /* O: 0 - void; 1 - monitor mode for standard; 2 - queue mode for standard;
+            int32_t nrt_mode,             /* O: 0 - void; 1 - monitor mode for standard; 2 - queue mode for standard;
                                         3 - monitor mode for snow; 4 - queue mode for snow */
             output_nrtmodel: nrt model if monitor mode, empty if queue mode
             output_nrtqueue: obs queue if queue mode, empty if monitor mode
@@ -331,16 +333,16 @@ cpdef _sccd_detect(np.ndarray[np.int64_t, ndim=1, mode='c'] dates,
     if conse > DEFAULT_CONSE:
         raise RuntimeError("The inputted conse is longer than the maximum conse for S-CCD: {}".format(DEFAULT_CONSE))
 
-    cdef int valid_num_scenes = qas.shape[0]
+    cdef int32_t valid_num_scenes = qas.shape[0]
     # allocate memory for rec_cg
-    cdef int num_fc = 0
-    cdef int num_nrt_queue = 0
-    cdef int num_fc_pinpoint = 0
+    cdef int32_t num_fc = 0
+    cdef int32_t num_nrt_queue = 0
+    cdef int32_t num_fc_pinpoint = 0
     rec_cg = np.zeros(NUM_FC_SCCD, dtype=sccd_dt)
     nrt_queue = np.zeros(NUM_NRT_QUEUE, dtype=nrtqueue_dt)
     nrt_model = np.zeros(1, dtype=nrtmodel_dt)
     rec_cg_pinpoint = np.zeros(NUM_FC_SCCD, dtype=pinpoint_dt)
-    cdef int nrt_mode = 0
+    cdef int32_t nrt_mode = 0
 
     if dates[-1] - dates[0] < 365.25:
         raise RuntimeError("The input data length is smaller than 1 year for pos = {}".format(pos))
@@ -349,15 +351,15 @@ cpdef _sccd_detect(np.ndarray[np.int64_t, ndim=1, mode='c'] dates,
     min_rmse = np.full(NRT_BAND, 0, dtype=np.short)
 
     # memory view
-    cdef long [:] dates_view = dates
-    cdef long [:] ts_b_view = ts_b
-    cdef long [:] ts_g_view = ts_g
-    cdef long [:] ts_r_view = ts_r
-    cdef long [:] ts_n_view = ts_n
-    cdef long [:] ts_s1_view = ts_s1
-    cdef long [:] ts_s2_view = ts_s2
-    cdef long [:] ts_t_view = ts_t
-    cdef long [:] qas_view = qas
+    cdef int64_t [:] dates_view = dates
+    cdef int64_t [:] ts_b_view = ts_b
+    cdef int64_t [:] ts_g_view = ts_g
+    cdef int64_t [:] ts_r_view = ts_r
+    cdef int64_t [:] ts_n_view = ts_n
+    cdef int64_t [:] ts_s1_view = ts_s1
+    cdef int64_t [:] ts_s2_view = ts_s2
+    cdef int64_t [:] ts_t_view = ts_t
+    cdef int64_t [:] qas_view = qas
     cdef short [:] min_rmse_view = min_rmse
 
     cdef Output_sccd [:] rec_cg_view = rec_cg
@@ -422,7 +424,7 @@ cpdef _sccd_update(sccd_pack,
                    np.ndarray[np.int64_t, ndim=1, mode='c'] ts_s2,
                    np.ndarray[np.int64_t, ndim=1, mode='c'] ts_t,
                    np.ndarray[np.int64_t, ndim=1, mode='c'] qas,
-                   double t_cg = 15.0863, int pos=1, int conse=6, bint b_c2=True,
+                   double t_cg = 15.0863, int32_t pos=1, int32_t conse=6, bint b_c2=True,
                    double gate_tcg=9.236, double predictability_tcg=15.086):
     """
     SCCD online update for new observations
@@ -450,24 +452,24 @@ cpdef _sccd_update(sccd_pack,
        namedtupe: SccdOutput
             rec_cg: the S-CCD outputs that characterizes each temporal segment
             min_rmse
-            int nrt_mode,             /* O: 0 - void; 1 - monitor mode for standard; 2 - queue mode for standard;
+            int32_t nrt_mode,             /* O: 0 - void; 1 - monitor mode for standard; 2 - queue mode for standard;
                                             3 - monitor mode for snow; 4 - queue mode for snow  */
             nrt_model: nrt model if monitor mode, empty if queue mode
             nrt_queue: obs queue if queue mode, empty if monitor mode
     """
 
-    cdef int valid_num_scenes = qas.shape[0]
+    cdef int32_t valid_num_scenes = qas.shape[0]
     # allocate memory for rec_cg
-    # cdef int num_fc = 0
-    # cdef int num_nrt_queue = 0
-    cdef int nrt_mode = sccd_pack.nrt_mode
+    # cdef int32_t num_fc = 0
+    # cdef int32_t num_nrt_queue = 0
+    cdef int32_t nrt_mode = sccd_pack.nrt_mode
 
     if nrt_mode != 0 and nrt_mode % 10 != 1 and nrt_mode % 10 != 2 and nrt_mode != 3 and nrt_mode != 4 and nrt_mode != 5:
         raise RuntimeError("Invalid nrt_node input {} for pos = {} ".format(nrt_mode, pos))
 
-    cdef int num_fc = len(sccd_pack.rec_cg)
-    cdef int num_nrt_queue = len(sccd_pack.nrt_queue)
-    cdef int num_fc_pinpoint = 0
+    cdef int32_t num_fc = len(sccd_pack.rec_cg)
+    cdef int32_t num_nrt_queue = len(sccd_pack.nrt_queue)
+    cdef int32_t num_fc_pinpoint = 0
     cdef Output_sccd_pinpoint* rec_cg_pinpoint = <Output_sccd_pinpoint*> PyMem_Malloc(sizeof(t4))
 
     # grab inputs from the input
@@ -491,15 +493,15 @@ cpdef _sccd_update(sccd_pack,
     cdef output_nrtqueue [:] nrt_queue_view = nrt_queue_new
     cdef output_nrtmodel [:] nrt_model_view = nrt_model_new
     cdef short [:] min_rmse_view = min_rmse
-    cdef long [:] dates_view = dates
-    cdef long [:] ts_b_view = ts_b
-    cdef long [:] ts_g_view = ts_g
-    cdef long [:] ts_r_view = ts_r
-    cdef long [:] ts_n_view = ts_n
-    cdef long [:] ts_s1_view = ts_s1
-    cdef long [:] ts_s2_view = ts_s2
-    cdef long [:] ts_t_view = ts_t
-    cdef long [:] qas_view = qas
+    cdef int64_t [:] dates_view = dates
+    cdef int64_t [:] ts_b_view = ts_b
+    cdef int64_t [:] ts_g_view = ts_g
+    cdef int64_t [:] ts_r_view = ts_r
+    cdef int64_t [:] ts_n_view = ts_n
+    cdef int64_t [:] ts_s1_view = ts_s1
+    cdef int64_t [:] ts_s2_view = ts_s2
+    cdef int64_t [:] ts_t_view = ts_t
+    cdef int64_t [:] qas_view = qas
 
     result = sccd(&ts_b_view[0], &ts_g_view[0], &ts_r_view[0], &ts_n_view[0], &ts_s1_view[0], &ts_s2_view[0],
                   &ts_t_view[0], &qas_view[0], &dates_view[0], valid_num_scenes, t_cg, &num_fc, &nrt_mode, &rec_cg_view[0],

--- a/src/python/pycold/utils.py
+++ b/src/python/pycold/utils.py
@@ -346,7 +346,7 @@ def read_data(path):
     Returns:
         A 2D numpy array.
     """
-    return np.genfromtxt(path, delimiter=",", dtype=np.int64).T
+    return np.genfromtxt(path, delimiter=",", dtype=np.int64,encoding="utf-8").T
 
 
 def date2matordinal(year, month, day):


### PR DESCRIPTION
- The `long` type has different bit-width specifications across platforms, replaced with `int64_t`.
- Modified the build configuration files to support building wheels using [MSYS2](https://www.msys2.org/), statically linking those libraries not provided by Windows.
- Other minor adjustments: encoding, dependencies, etc.

`.github/workflows/win_wheels.yml` provides a minimal working example of the build process.

Closes #26 